### PR TITLE
fixed critical data error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,6 @@ __pycache__/
 *.pyc
 .DS_Store
 **/.DS_Store
-pyconstructor.egg-info
+pyconstructor.egg-info/
 .coverage
 dist

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-include src/templates/config_templates/*.yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyconstructor"
-version = "0.1.2"
+version = "0.1.3"
 description = "CLI tool for generating DDD architecture in Python projects"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -61,8 +61,8 @@ indent-style = "space"
 line-ending = "auto"
 
 [tool.setuptools]
-package-dir = {"" = "."}
-package-data = {"*" = ["src/templates/config_templates/*.yaml"]}
+package-dir = {"" = "src"}
+package-data = {"*" = ["templates/config_templates/*.yaml"]}
 include-package-data = true
 
 [tool.mypy]


### PR DESCRIPTION
## Summary by Sourcery

Bump version to 0.1.3 and improve packaging by moving source code to the src directory, updating template data paths, and removing MANIFEST.in.

Enhancements:
- Reorganize package directory to 'src'
- Update package-data path for configuration templates

Build:
- Remove MANIFEST.in to rely on setuptools include-package-data

Chores:
- Increment project version to 0.1.3