### PR TITLE
critical error with root path fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Python Version](https://img.shields.io/badge/python-3.12%2B-blue)](https://www.python.org/downloads/)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
-[![PyPI version](https://badge.fury.io/py/pyconstructor.svg)](https://badge.fury.io/py/pyconstructor)
 
 PyConstructor is a command-line tool
 that helps developers quickly create a project structure following Domain-Driven Design

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyconstructor"
-version = "0.1.3"
+version = "0.1.4"
 description = "CLI tool for generating DDD architecture in Python projects"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -42,7 +42,7 @@ dev = [
 ]
 
 [project.scripts]
-pyc = "src.main:cli"
+pyc = "main:cli"
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
## Summary by Sourcery

Fix the CLI entry point import path, update the project version to 0.1.4, and remove the outdated PyPI badge from the README.

Bug Fixes:
- Fix CLI script entry point path in pyproject.toml

Documentation:
- Remove outdated PyPI badge from README

Chores:
- Bump project version to 0.1.4